### PR TITLE
`getKeyString` no longer returns double `?` for parameters

### DIFF
--- a/brandai-cli.js
+++ b/brandai-cli.js
@@ -59,7 +59,7 @@ function getKeyString(firstParam) {
   if (!sharedKey) {
     return '';
   }
-  var keyString = firstParam ? '?key=' + sharedKey : '&key=' + sharedKey;
+  var keyString = (firstParam ? '' : '&') + 'key=' + sharedKey;
   return keyString;
 };
 


### PR DESCRIPTION
Addresses issue #1.

Now, when the `firstParam` flag is `true` in `getKeyString`, `key=[sharedKey]` is returned without a leading `?`. If `firstParam` is `false`, it prepends a `&`, same as before.